### PR TITLE
refacto: centralize metadata in the workspace’s `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [workspace]
-
 members = [
   "zenoh-flow",
   "zenoh-flow-derive",
@@ -20,6 +19,19 @@ members = [
   "zfctl",
   "cargo-zenoh-flow",
 ]
+
+
+[workspace.package]
+version = "0.4.0"
+authors = ["ZettaScale Zenoh Team <zenoh@zettascale.tech>"]
+categories = ["network-programming"]
+description = "Zenoh-Flow: a Zenoh-based data flow programming framework for computations that span from the cloud to the device."
+edition = "2018"
+homepage = "https://github.com/eclipse-zenoh/zenoh-flow"
+license = " EPL-2.0 OR Apache-2.0"
+readme = "README.md"
+repository = "https://github.com/eclipse-zenoh/zenoh-flow"
+
 
 [profile.dev]
 debug=true

--- a/cargo-zenoh-flow/Cargo.toml
+++ b/cargo-zenoh-flow/Cargo.toml
@@ -14,17 +14,15 @@
 
 [package]
 name = "cargo-zenoh-flow"
-version = "0.4.0"
-repository = "https://github.com/eclipse-zenoh/zenoh-flow"
-homepage = "http://zenoh.io"
-authors = ["kydos <angelo@icorsaro.net>",
-           "gabrik <gabriele.baldoni@gmail.com>",
-           "Julien Loudet <julien.loudet@zettascale.tech>",]
-edition = "2018"
-license = " EPL-2.0 OR Apache-2.0"
-categories = ["network-programming"]
-description = "Zenoh-Flow: zenoh-based data-flow programming framework for computations that span from the cloud to the device."
-readme = "README.md"
+version.workspace = true
+authors.workspace = true
+categories.workspace = true
+description.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
 
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/zenoh-flow-daemon/Cargo.toml
+++ b/zenoh-flow-daemon/Cargo.toml
@@ -14,17 +14,15 @@
 
 [package]
 name = "zenoh-flow-daemon"
-version = "0.4.0"
-repository = "https://github.com/eclipse-zenoh/zenoh-flow"
-homepage = "http://zenoh.io"
-authors = ["kydos <angelo@icorsaro.net>",
-           "gabrik <gabriele.baldoni@gmail.com>",
-           "Julien Loudet <julien.loudet@zettascale.tech>",]
-edition = "2018"
-license = " EPL-2.0 OR Apache-2.0"
-categories = ["network-programming"]
-description = "Zenoh-Flow: zenoh-based data-flow programming framework for computations that span from the cloud to the device."
-readme = "README.md"
+version.workspace = true
+authors.workspace = true
+categories.workspace = true
+description.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/zenoh-flow-derive/Cargo.toml
+++ b/zenoh-flow-derive/Cargo.toml
@@ -14,17 +14,15 @@
 
 [package]
 name = "zenoh-flow-derive"
-version = "0.4.0"
-repository = "https://github.com/eclipse-zenoh/zenoh-flow"
-homepage = "http://zenoh.io"
-authors = ["kydos <angelo@icorsaro.net>",
-           "gabrik <gabriele.baldoni@gmail.com>",
-           "Julien Loudet <julien.loudet@zettascale.tech>",]
-edition = "2018"
-license = " EPL-2.0 OR Apache-2.0"
-categories = ["network-programming"]
-description = "Zenoh-Flow: zenoh-based data-flow programming framework for computations that span from the cloud to the device."
-readme = "README.md"
+version.workspace = true
+authors.workspace = true
+categories.workspace = true
+description.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
 
 # To build with debug on macros: RUSTFLAGS="-Z macro-backtrace"
 

--- a/zenoh-flow/Cargo.toml
+++ b/zenoh-flow/Cargo.toml
@@ -14,19 +14,15 @@
 
 [package]
 name = "zenoh-flow"
-version = "0.4.0"
-repository = "https://github.com/eclipse-zenoh/zenoh-flow"
-homepage = "http://zenoh.io"
-authors = ["kydos <angelo@icorsaro.net>",
-           "gabrik <gabriele.baldoni@gmail.com>",
-           "Julien Loudet <julien.loudet@zettascale.tech>",]
-edition = "2018"
-license = " EPL-2.0 OR Apache-2.0"
-categories = ["network-programming"]
-description = "Zenoh-Flow: zenoh-based data-flow programming framework for computations that span from the cloud to the device."
-readme = "README.md"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+version.workspace = true
+authors.workspace = true
+categories.workspace = true
+description.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
 
 [dependencies]
 anyhow = { version = "1.0", default-features = false, features = ["std"] }

--- a/zfctl/Cargo.toml
+++ b/zfctl/Cargo.toml
@@ -14,17 +14,15 @@
 
 [package]
 name = "zfctl"
-version = "0.4.0"
-repository = "https://github.com/eclipse-zenoh/zenoh-flow"
-homepage = "http://zenoh.io"
-authors = ["kydos <angelo@icorsaro.net>",
-           "gabrik <gabriele.baldoni@gmail.com>",
-           "Julien Loudet <julien.loudet@zettascale.tech>",]
-edition = "2018"
-license = " EPL-2.0 OR Apache-2.0"
-categories = ["network-programming"]
-description = "Zenoh-Flow command line tool"
-readme = "README.md"
+version.workspace = true
+authors.workspace = true
+categories.workspace = true
+description.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
 
 [dependencies]
 async-std = { version = "=1.11.0", features = ["attributes"] }


### PR DESCRIPTION
As indicated in the title, let’s keep the metadata in the workspace’s `Cargo.toml`.

The review is to check if we agree on the values.