### PR TITLE
Unifying Deserializable and ZFData traits

### DIFF
--- a/cargo-zenoh-flow/src/utils.rs
+++ b/cargo-zenoh-flow/src/utils.rs
@@ -117,7 +117,7 @@ pub fn from_manifest(
     let manifest_path = Path::new(&root_package.manifest_path);
 
     let manifest_dir = manifest_path.parent().unwrap();
-    let content = std::fs::read(&manifest_path)?;
+    let content = std::fs::read(manifest_path)?;
 
     let metadata = toml::from_slice::<Cargo>(&content)?
         .package

--- a/zenoh-flow/src/lib.rs
+++ b/zenoh-flow/src/lib.rs
@@ -53,8 +53,12 @@ pub use zfresult::{DaemonResult, ZFResult as Result};
 pub mod prelude {
 
     pub use crate::traits::{
-        Deserializable, DowncastAny, Node, OperatorFactoryTrait, SinkFactoryTrait,
-        SourceFactoryTrait, ZFData,
+        DowncastAny,
+        Node,
+        OperatorFactoryTrait,
+        SinkFactoryTrait,
+        SourceFactoryTrait,
+        ZFData,
     };
     pub use crate::types::{
         Configuration, Context, Data, DataMessage, Input, Inputs, Message, NodeId, Output, Outputs,

--- a/zenoh-flow/src/lib.rs
+++ b/zenoh-flow/src/lib.rs
@@ -53,12 +53,7 @@ pub use zfresult::{DaemonResult, ZFResult as Result};
 pub mod prelude {
 
     pub use crate::traits::{
-        DowncastAny,
-        Node,
-        OperatorFactoryTrait,
-        SinkFactoryTrait,
-        SourceFactoryTrait,
-        ZFData,
+        DowncastAny, Node, OperatorFactoryTrait, SinkFactoryTrait, SourceFactoryTrait, ZFData,
     };
     pub use crate::types::{
         Configuration, Context, Data, DataMessage, Input, Inputs, Message, NodeId, Output, Outputs,

--- a/zenoh-flow/src/traits.rs
+++ b/zenoh-flow/src/traits.rs
@@ -45,12 +45,12 @@ pub trait DowncastAny {
 /// This trait abstracts the user's data type inside Zenoh Flow.
 ///
 /// User types should implement this trait otherwise Zenoh Flow will
-/// not be able to handle the data, and serialize them when needed.
+/// not be able to handle the data, serialize and deserialize them when needed.
 ///
 /// Example:
 /// ```no_run
 /// use zenoh_flow::zenoh_flow_derive::ZFData;
-/// use zenoh_flow::prelude::{ZFData, Result};
+/// use zenoh_flow::prelude::*;
 ///
 /// #[derive(Debug, Clone, ZFData)]
 /// pub struct MyString(pub String);
@@ -58,32 +58,8 @@ pub trait DowncastAny {
 ///     fn try_serialize(&self) -> Result<Vec<u8>> {
 ///         Ok(self.0.as_bytes().to_vec())
 ///     }
-/// }
-/// ```
-pub trait ZFData: DowncastAny + Debug + Send + Sync {
-    /// Tries to serialize the data as `Vec<u8>`
-    ///
-    /// # Errors
-    /// If it fails to serialize an error variant will be returned.
-    fn try_serialize(&self) -> ZFResult<Vec<u8>>;
-}
-
-/// This trait abstract user's type deserialization.
 ///
-/// User types should implement this trait otherwise Zenoh Flow will
-/// not be able to handle the data, and deserialize them when needed.
-///
-/// Example:
-/// ```no_run
-///
-/// use zenoh_flow::prelude::*;
-/// use zenoh_flow::zenoh_flow_derive::ZFData;
-///
-/// #[derive(Debug, Clone, ZFData)]
-/// pub struct MyString(pub String);
-///
-/// impl Deserializable for MyString {
-///     fn try_deserialize(bytes: &[u8]) -> Result<MyString>
+/// fn try_deserialize(bytes: &[u8]) -> Result<MyString>
 ///     where
 ///         Self: Sized,
 ///     {
@@ -93,7 +69,13 @@ pub trait ZFData: DowncastAny + Debug + Send + Sync {
 ///     }
 /// }
 /// ```
-pub trait Deserializable {
+pub trait ZFData: DowncastAny + Debug + Send + Sync {
+    /// Tries to serialize the data as `Vec<u8>`
+    ///
+    /// # Errors
+    /// If it fails to serialize an error variant will be returned.
+    fn try_serialize(&self) -> ZFResult<Vec<u8>>;
+
     /// Tries to deserialize from a slice of `u8`.
     ///
     /// # Errors
@@ -130,7 +112,7 @@ pub trait Deserializable {
 ///   async fn iteration(&self) -> Result<()> {
 ///     // To mutate the state, first lock it.
 ///     // let state = self.state.lock().await;
-///     
+///
 ///     if let Ok(Message::Data(mut message)) = self.input.recv_async().await {
 ///       let data = message.get_inner_data();
 ///       self.output.send_async(data.clone(), None).await?;
@@ -165,7 +147,7 @@ pub trait Node: Send + Sync {
 ///
 /// pub struct MySource {
 ///   output: Output,
-///   
+///
 ///   // If we read from a sensor we can keep a reference here.
 ///   // If we need to mutate it, it could go behind an `Arc<Mutex<T>>`.
 ///   // sensor: Sensor,
@@ -175,7 +157,7 @@ pub trait Node: Send + Sync {
 /// impl Node for MySource {
 ///   async fn iteration(&self) -> Result<()> {
 ///     async_std::task::sleep(Duration::from_secs(1)).await;
-///     
+///
 ///     // We can read data from a sensor every second and send it.
 ///     // let data = self.sensor.read().await;
 ///     // self.output.send_async(data, None).await;
@@ -246,7 +228,7 @@ pub trait SourceFactoryTrait: Send + Sync {
 /// impl Node for MyOperator {
 ///   async fn iteration(&self) -> Result<()> {
 ///     // let state = self.state.lock().await;
-///     
+///
 ///     if let Ok(Message::Data(mut message)) = self.input.recv_async().await {
 ///       let mut data = message.get_inner_data().clone();
 ///       // Computation based on the data would be performed here. For instance:

--- a/zenoh-flow/src/types/mod.rs
+++ b/zenoh-flow/src/types/mod.rs
@@ -96,7 +96,7 @@ impl Data {
     /// variant will be returned.
     pub fn try_get<Typed>(&mut self) -> Result<&Typed>
     where
-        Typed: ZFData + crate::traits::Deserializable + 'static,
+        Typed: ZFData + 'static,
     {
         *self = (match &self {
             Self::Bytes(bytes) => {

--- a/zenoh-flow/tests/data.rs
+++ b/zenoh-flow/tests/data.rs
@@ -16,7 +16,6 @@ use serde::{Deserialize, Serialize};
 use std::convert::From;
 use std::sync::Arc;
 use zenoh_flow::prelude::*;
-use zenoh_flow::traits::{Deserializable, ZFData};
 use zenoh_flow::types::Data;
 use zenoh_flow::zenoh_flow_derive::ZFData;
 
@@ -34,9 +33,7 @@ impl ZFData for TestData {
             .as_bytes()
             .to_vec())
     }
-}
 
-impl Deserializable for TestData {
     fn try_deserialize(bytes: &[u8]) -> Result<TestData>
     where
         Self: Sized,

--- a/zenoh-flow/tests/dataflow.rs
+++ b/zenoh-flow/tests/dataflow.rs
@@ -25,7 +25,7 @@ use zenoh_flow::runtime::dataflow::instance::DataFlowInstance;
 use zenoh_flow::runtime::dataflow::loader::{Loader, LoaderConfig};
 use zenoh_flow::runtime::RuntimeContext;
 use zenoh_flow::traits::{
-    Deserializable, Node, OperatorFactoryTrait, SinkFactoryTrait, SourceFactoryTrait, ZFData,
+    Node, OperatorFactoryTrait, SinkFactoryTrait, SourceFactoryTrait, ZFData,
 };
 use zenoh_flow::types::{Configuration, Context, Data, Inputs, Message, Outputs, Streams};
 use zenoh_flow::zenoh_flow_derive::ZFData;
@@ -38,9 +38,7 @@ impl ZFData for ZFUsize {
     fn try_serialize(&self) -> Result<Vec<u8>> {
         Ok(self.0.to_ne_bytes().to_vec())
     }
-}
 
-impl Deserializable for ZFUsize {
     fn try_deserialize(bytes: &[u8]) -> Result<Self>
     where
         Self: Sized,


### PR DESCRIPTION
This PR unifies the `Deserializable` and `ZFData` traits, facilitating developers in implementing Zenoh-Flow compatible types.

**Before**:
```rust
use serde::{Deserialize, Serialize};
use zenoh_flow::prelude::*;

#[derive(Debug, ZFData, Clone, Serialize, Deserialize)]
struct TestData {
    pub field1: u8,
    pub field2: String,
    pub field3: f64,
}

impl ZFData for TestData {
    fn try_serialize(&self) -> Result<Vec<u8>> {
        Ok(serde_json::to_string(self)
            .map_err(|e| zferror!(ErrorKind::SerializationError, e))?
            .as_bytes()
            .to_vec())
    }
}

impl Deserializable for TestData {
    fn try_deserialize(bytes: &[u8]) -> Result<TestData>
    where
        Self: Sized,
    {
        let json = String::from_utf8_lossy(bytes);
        let data: TestData =
            serde_json::from_str(&json).map_err(|e| zferror!(ErrorKind::DeseralizationError, e))?;
        Ok(data)
    }
}

```

**After**:

```rust
use serde::{Deserialize, Serialize};
use zenoh_flow::prelude::*;

#[derive(Debug, ZFData, Clone, Serialize, Deserialize)]
struct TestData {
    pub field1: u8,
    pub field2: String,
    pub field3: f64,
}

impl ZFData for TestData {
    fn try_serialize(&self) -> Result<Vec<u8>> {
        Ok(serde_json::to_string(self)
            .map_err(|e| zferror!(ErrorKind::SerializationError, e))?
            .as_bytes()
            .to_vec())
    }

   fn try_deserialize(bytes: &[u8]) -> Result<TestData>
    where
        Self: Sized,
    {
        let json = String::from_utf8_lossy(bytes);
        let data: TestData =
            serde_json::from_str(&json).map_err(|e| zferror!(ErrorKind::DeseralizationError, e))?;
        Ok(data)
    }
}



```