### PR TITLE
feat: impl DerefMut for DataMessage

### DIFF
--- a/zenoh-flow/src/types/message.rs
+++ b/zenoh-flow/src/types/message.rs
@@ -21,6 +21,7 @@ use crate::zfresult::ErrorKind;
 use crate::Result;
 
 use serde::{Deserialize, Serialize};
+use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 use std::{cmp::Ordering, fmt::Debug};
 use uhlc::Timestamp;
@@ -33,6 +34,20 @@ use uuid::Uuid;
 pub struct DataMessage {
     pub(crate) data: Data,
     pub(crate) timestamp: Timestamp,
+}
+
+impl Deref for DataMessage {
+    type Target = Data;
+
+    fn deref(&self) -> &Self::Target {
+        &self.data
+    }
+}
+
+impl DerefMut for DataMessage {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.data
+    }
 }
 
 impl DataMessage {

--- a/zenoh-flow/tests/dataflow.rs
+++ b/zenoh-flow/tests/dataflow.rs
@@ -120,12 +120,12 @@ struct GenericSink {
 impl Node for GenericSink {
     async fn iteration(&self) -> Result<()> {
         if let Ok(Message::Data(mut msg)) = self.input.recv_async().await {
-            let data = msg.get_inner_data().try_get::<ZFUsize>()?;
+            let data = msg.try_get::<ZFUsize>()?;
             assert_eq!(data.0, COUNTER.load(Ordering::Relaxed));
         }
 
         if let Ok(Message::Data(mut msg)) = self.input_callback.recv_async().await {
-            let data = msg.get_inner_data().try_get::<ZFUsize>()?;
+            let data = msg.try_get::<ZFUsize>()?;
             assert_eq!(data.0, COUNTER_CALLBACK.load(Ordering::Relaxed));
         }
 
@@ -163,7 +163,7 @@ struct NoOp {
 impl Node for NoOp {
     async fn iteration(&self) -> Result<()> {
         if let Ok(Message::Data(mut msg)) = self.input.recv_async().await {
-            let data = msg.get_inner_data().try_get::<ZFUsize>()?;
+            let data = msg.try_get::<ZFUsize>()?;
             assert_eq!(data.0, COUNTER.load(Ordering::Relaxed));
             let out_data = Data::from(data.clone());
             self.output.send_async(out_data, None).await?;
@@ -212,9 +212,7 @@ impl OperatorFactoryTrait for NoOpCallbackFactory {
                 async move {
                     println!("Entering callback");
                     let data = match message {
-                        Message::Data(mut data) => {
-                            data.get_inner_data().try_get::<ZFUsize>()?.clone()
-                        }
+                        Message::Data(mut data) => data.try_get::<ZFUsize>()?.clone(),
                         _ => return Err(zferror!(ErrorKind::Unsupported).into()),
                     };
 


### PR DESCRIPTION
This PR allows simplifying this line:

```rust
let data = msg.get_inner_data().try_get::<X>()?;
```

into:

```rust
let data = msg.try_get::<X>()?;
```