### PR TITLE
refacto: simplify the `export_*_factory` macros

### DIFF
--- a/zenoh-flow/src/macros.rs
+++ b/zenoh-flow/src/macros.rs
@@ -22,11 +22,10 @@
 /// use std::sync::Arc;
 /// use zenoh_flow::prelude::*;
 ///
-/// pub struct MyOperator;
-///
+/// pub struct MyOperatorFactory;
 ///
 /// #[async_trait]
-/// impl OperatorFactoryTrait for MyOperator {
+/// impl OperatorFactoryTrait for MyOperatorFactory {
 /// async fn new_operator(
 ///     &self,
 ///     context: &mut Context,
@@ -38,16 +37,12 @@
 ///     }
 /// }
 ///
-/// export_operator_factory!(register);
-///
-/// fn register() -> Result<Arc<dyn OperatorFactoryTrait>> {
-///    Ok(Arc::new(MyOperator) as Arc<dyn OperatorFactoryTrait>)
-/// }
+/// export_operator_factory!(MyOperatorFactory {});
 /// ```
 ///
 #[macro_export]
 macro_rules! export_operator_factory {
-    ($register:expr) => {
+    ($factory:expr) => {
         #[doc(hidden)]
         #[no_mangle]
         pub static zfoperator_factory_declaration:
@@ -55,7 +50,7 @@ macro_rules! export_operator_factory {
             $crate::runtime::dataflow::loader::NodeDeclaration::<OperatorFactoryTrait> {
                 rustc_version: $crate::runtime::dataflow::loader::RUSTC_VERSION,
                 core_version: $crate::runtime::dataflow::loader::CORE_VERSION,
-                register: $register,
+                register: || std::sync::Arc::new($factory),
             };
     };
 }
@@ -70,11 +65,10 @@ macro_rules! export_operator_factory {
 /// use std::sync::Arc;
 /// use zenoh_flow::prelude::*;
 ///
-/// pub struct MySource;
-///
+/// pub struct MySourceFactory;
 ///
 /// #[async_trait]
-/// impl SourceFactoryTrait for MySource {
+/// impl SourceFactoryTrait for MySourceFactory {
 ///   async fn new_source(
 ///       &self,
 ///       context: &mut Context,
@@ -85,17 +79,12 @@ macro_rules! export_operator_factory {
 ///     }
 /// }
 ///
-/// export_source_factory!(register);
-///
-/// fn register() -> Result<Arc<dyn SourceFactoryTrait>> {
-///    Ok(Arc::new(MySource) as Arc<dyn SourceFactoryTrait>)
-/// }
-///
+/// export_source_factory!(MySourceFactory {});
 /// ```
 ///
 #[macro_export]
 macro_rules! export_source_factory {
-    ($register:expr) => {
+    ($factory:expr) => {
         #[doc(hidden)]
         #[no_mangle]
         pub static zfsource_factory_declaration:
@@ -103,7 +92,7 @@ macro_rules! export_source_factory {
             $crate::runtime::dataflow::loader::NodeDeclaration::<SourceFactoryTrait> {
                 rustc_version: $crate::runtime::dataflow::loader::RUSTC_VERSION,
                 core_version: $crate::runtime::dataflow::loader::CORE_VERSION,
-                register: $register,
+                register: || std::sync::Arc::new($factory),
             };
     };
 }
@@ -118,11 +107,10 @@ macro_rules! export_source_factory {
 /// use std::sync::Arc;
 /// use zenoh_flow::prelude::*;
 ///
-/// pub struct MySink;
-///
+/// pub struct MySinkFactory;
 ///
 /// #[async_trait]
-/// impl SinkFactoryTrait for MySink {
+/// impl SinkFactoryTrait for MySinkFactory {
 ///   async fn new_sink(
 ///       &self,
 ///       context: &mut Context,
@@ -133,18 +121,12 @@ macro_rules! export_source_factory {
 ///     }
 /// }
 ///
-/// export_sink_factory!(register);
-///
-///
-/// fn register() -> Result<Arc<dyn SinkFactoryTrait>> {
-///    Ok(Arc::new(MySink) as Arc<dyn SinkFactoryTrait>)
-/// }
-///
+/// export_sink_factory!(MySinkFactory {});
 /// ```
 ///
 #[macro_export]
 macro_rules! export_sink_factory {
-    ($register:expr) => {
+    ($factory:expr) => {
         #[doc(hidden)]
         #[no_mangle]
         pub static zfsink_factory_declaration: $crate::runtime::dataflow::loader::NodeDeclaration<
@@ -152,7 +134,7 @@ macro_rules! export_sink_factory {
         > = $crate::runtime::dataflow::loader::NodeDeclaration::<SinkFactoryTrait> {
             rustc_version: $crate::runtime::dataflow::loader::RUSTC_VERSION,
             core_version: $crate::runtime::dataflow::loader::CORE_VERSION,
-            register: $register,
+            register: || std::sync::Arc::new($factory),
         };
     };
 }

--- a/zenoh-flow/src/runtime/dataflow/loader.rs
+++ b/zenoh-flow/src/runtime/dataflow/loader.rs
@@ -75,7 +75,7 @@ impl FactorySymbol {
 pub struct NodeDeclaration<T: ?Sized> {
     pub rustc_version: &'static str,
     pub core_version: &'static str,
-    pub register: fn() -> Result<Arc<T>>,
+    pub register: fn() -> Arc<T>,
 }
 
 /// Extensible support for different implementations
@@ -434,7 +434,7 @@ impl Loader {
             return Err(zferror!(ErrorKind::VersionMismatch).into());
         }
 
-        Ok((library, (decl.register)()?))
+        Ok((library, (decl.register)()))
     }
 
     /// Converts the `Url` to a `PathBuf`


### PR DESCRIPTION
This PR "simplifies" the writing of the `export_*_factory` macros by automatically implementing the `register` function. Users of the macros will thus only have to provide an instance of the factory as parameter.

Before:

```rust
export_operator_factory!(register);

fn register() -> Result<Arc<dyn OperatorFactoryTrait>> {
    Ok(Arc::new(MyOperatorFactory))
}
```

After:

```rust
export_operator_factory!(MyOperatorFactory {});
```

----

I removed the `Result` as I don’t see why this operation would fail, especially now that we write it for the users.

----

- [x] I have tested this change by launching a data-flow via the daemon (single daemon).