### PR TITLE
fix: unify path declaration

### DIFF
--- a/zenoh-flow/src/lib.rs
+++ b/zenoh-flow/src/lib.rs
@@ -46,6 +46,7 @@ pub mod traits;
 pub mod types;
 pub mod zfdata;
 
+pub(crate) mod utils;
 pub mod zfresult;
 
 pub use anyhow::anyhow;

--- a/zenoh-flow/src/model/descriptor/node/operator.rs
+++ b/zenoh-flow/src/model/descriptor/node/operator.rs
@@ -14,7 +14,7 @@
 
 use crate::model::descriptor::link::{CompositeInputDescriptor, CompositeOutputDescriptor};
 use crate::model::descriptor::node::NodeDescriptor;
-use crate::model::descriptor::{LinkDescriptor, PortDescriptor, Vars};
+use crate::model::descriptor::{LinkDescriptor, PortDescriptor};
 use crate::types::configuration::Merge;
 use crate::types::{Configuration, NodeId};
 use crate::zfresult::{ErrorKind, ZFResult as Result};
@@ -213,9 +213,7 @@ impl CompositeOperatorDescriptor {
                 descriptor,
                 configuration,
             } = o;
-            let data = async_std::fs::read_to_string(&descriptor).await?;
-            let description = Vars::expand_mustache_yaml(&data)?;
-
+            let description = super::try_load_descriptor(&descriptor).await?;
             let configuration = self.configuration.clone().merge_overwrite(configuration);
 
             let res_simple = OperatorDescriptor::from_yaml(&description);

--- a/zenoh-flow/src/model/descriptor/tests/composite-nested.yml
+++ b/zenoh-flow/src/model/descriptor/tests/composite-nested.yml
@@ -15,10 +15,10 @@ outputs:
 
 operators:
   - id: operator-1
-    descriptor: ./src/model/descriptor/tests/operator-1.yml
+    descriptor: file://./src/model/descriptor/tests/operator-1.yml
 
   - id: operator-2
-    descriptor: ./src/model/descriptor/tests/operator-2.yml
+    descriptor: file://./src/model/descriptor/tests/operator-2.yml
 
 
 links:

--- a/zenoh-flow/src/model/descriptor/tests/data-flow-recursion-duplicate-composite.yml
+++ b/zenoh-flow/src/model/descriptor/tests/data-flow-recursion-duplicate-composite.yml
@@ -1,19 +1,22 @@
 flow: test-recursion-ok
 
+vars:
+  BASE_DIR: file://./src/model/descriptor/tests
+
 sources:
   - id: source-composite
-    descriptor: ./src/model/descriptor/tests/source-composite.yml
+    descriptor: "{{ BASE_DIR }}/source-composite.yml"
 
 operators:
   - id: operator-composite-1
-    descriptor: ./src/model/descriptor/tests/operator-composite.yml
+    descriptor: "{{ BASE_DIR }}/operator-composite.yml"
 
   - id: operator-composite-2
-    descriptor: ./src/model/descriptor/tests/operator-composite.yml
+    descriptor: "{{ BASE_DIR }}/operator-composite.yml"
 
 sinks:
   - id: sink-composite
-    descriptor: ./src/model/descriptor/tests/sink-composite.yml
+    descriptor: "{{ BASE_DIR }}/sink-composite.yml"
 
 links:
   - from:

--- a/zenoh-flow/src/model/descriptor/tests/data-flow-recursion.yml
+++ b/zenoh-flow/src/model/descriptor/tests/data-flow-recursion.yml
@@ -1,19 +1,22 @@
 flow: test-recursion
 
+vars:
+  BASE_DIR: file://./src/model/dataflow/tests
+
 sources:
   - id: source-1
-    descriptor: ./src/model/dataflow/tests/source-1.yml
+    descriptor: "{{ BASE_DIR }}/source-1.yml"
 
 operators:
   - id: operator-1
-    descriptor: ./src/model/dataflow/tests/operator-1.yml
+    descriptor: "{{ BASE_DIR }}/operator-1.yml"
 
   - id: operator-infinite
-    descriptor: ./src/model/dataflow/tests/operator-infinite.yml
+    descriptor: "{{ BASE_DIR }}/operator-infinite.yml"
 
 sinks:
   - id: sink-1
-    descriptor: ./src/model/dataflow/tests/sink-1.yml
+    descriptor: "{{ BASE_DIR }}/sink-1.yml"
 
 links:
   - from:

--- a/zenoh-flow/src/model/descriptor/tests/data-flow.yml
+++ b/zenoh-flow/src/model/descriptor/tests/data-flow.yml
@@ -1,7 +1,7 @@
 flow: test
 
 vars:
-  PATH: ./src/model/descriptor/tests
+  PATH: file://./src/model/descriptor/tests
 
 configuration:
   foo: "global-outer"

--- a/zenoh-flow/src/model/descriptor/tests/flatten-composite.rs
+++ b/zenoh-flow/src/model/descriptor/tests/flatten-composite.rs
@@ -34,12 +34,12 @@ fn test_flatten_composite_descriptor_non_nested() {
         operators: vec![
             NodeDescriptor {
                 id: "my-operator-1".into(),
-                descriptor: "./src/model/descriptor/tests/operator-1.yml".into(),
+                descriptor: "file://./src/model/descriptor/tests/operator-1.yml".into(),
                 configuration: None,
             },
             NodeDescriptor {
                 id: "my-operator-2".into(),
-                descriptor: "./src/model/descriptor/tests/operator-2.yml".into(),
+                descriptor: "file://./src/model/descriptor/tests/operator-2.yml".into(),
                 configuration: None,
             },
         ],
@@ -161,17 +161,17 @@ fn test_flatten_composite_descriptor_nested() {
         operators: vec![
             NodeDescriptor {
                 id: "composite-outer-o".into(),
-                descriptor: "./src/model/descriptor/tests/composite-outer.yml".into(),
+                descriptor: "file://./src/model/descriptor/tests/composite-outer.yml".into(),
                 configuration: None,
             },
             NodeDescriptor {
                 id: "composite-nested".into(),
-                descriptor: "./src/model/descriptor/tests/composite-nested.yml".into(),
+                descriptor: "file://./src/model/descriptor/tests/composite-nested.yml".into(),
                 configuration: None,
             },
             NodeDescriptor {
                 id: "composite-outer-i".into(),
-                descriptor: "./src/model/descriptor/tests/composite-outer.yml".into(),
+                descriptor: "file://./src/model/descriptor/tests/composite-outer.yml".into(),
                 configuration: None,
             },
         ],

--- a/zenoh-flow/src/model/descriptor/tests/operator-composite.yml
+++ b/zenoh-flow/src/model/descriptor/tests/operator-composite.yml
@@ -1,7 +1,7 @@
 id: composite
 
 vars:
-  path: ./src/model/descriptor/tests
+  path: file://./src/model/descriptor/tests
 
 configuration:
   foo: "composite-outer"

--- a/zenoh-flow/src/model/descriptor/tests/operator-infinite.yml
+++ b/zenoh-flow/src/model/descriptor/tests/operator-infinite.yml
@@ -15,13 +15,13 @@ outputs:
 
 operators:
   - id: operator-1
-    descriptor: ./src/model/dataflow/tests/operator-1.yml
+    descriptor: file://./src/model/dataflow/tests/operator-1.yml
 
   - id: operator-infinite
-    descriptor: ./src/model/dataflow/tests/operator-infinite.yml
+    descriptor: file://./src/model/dataflow/tests/operator-infinite.yml
 
   - id: operator-2
-    descriptor: ./src/model/dataflow/tests/operator-2.yml
+    descriptor: file://./src/model/dataflow/tests/operator-2.yml
 
 
 links:

--- a/zenoh-flow/src/model/descriptor/tests/sub-operator-composite.yml
+++ b/zenoh-flow/src/model/descriptor/tests/sub-operator-composite.yml
@@ -1,5 +1,8 @@
 id: sub-operator-composite
 
+vars:
+  BASE_DIR: file://./src/model/descriptor/tests
+
 
 inputs:
   - id: sub-operator-composite-in
@@ -15,10 +18,10 @@ outputs:
 
 operators:
   - id: sub-sub-operator-1
-    descriptor: ./src/model/descriptor/tests/sub-sub-operator-1.yml
+    descriptor: "{{ BASE_DIR }}/sub-sub-operator-1.yml"
 
   - id: sub-sub-operator-2
-    descriptor: ./src/model/descriptor/tests/sub-sub-operator-2.yml
+    descriptor: "{{ BASE_DIR }}/sub-sub-operator-2.yml"
 
 
 links:

--- a/zenoh-flow/src/utils.rs
+++ b/zenoh-flow/src/utils.rs
@@ -1,0 +1,76 @@
+//
+// Copyright (c) 2022 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+use crate::prelude::ErrorKind;
+use crate::{bail, zferror, Result};
+use std::path::{Path, PathBuf};
+use url::Url;
+
+/// Given a string representing a [`Url`](`url::Url`), transform it into a
+/// [`PathBuf`](`std::path::PathBuf`).
+///
+/// Only one scheme, for now, is supported: `file://`. This will change in upcoming releases of
+/// Zenoh-Flow.
+///
+/// # Errors
+///
+/// This function will return an error in the following situations:
+/// - The provided string does not match the syntax of a [`Url`](`url::Url`).
+/// - The scheme used for the url is NOT `file://`.
+/// - The resulting path cannot be [`canonicalized`](`std::fs::canonicalize`).
+pub(crate) fn try_make_file_path(url_str: &str) -> Result<PathBuf> {
+    let uri = Url::parse(url_str).map_err(|err| zferror!(ErrorKind::ParsingError, err))?;
+
+    if uri.scheme() != "file" {
+        bail!(
+            ErrorKind::ParsingError,
+            "Only the 'file://' scheme is supported, found: {}://",
+            uri.scheme()
+        );
+    }
+
+    let mut path = PathBuf::new();
+    #[cfg(test)]
+    {
+        path.push(env!("CARGO_MANIFEST_DIR"));
+    }
+
+    let file_path = match uri.host_str() {
+        Some(h) => format!("{}{}", h, uri.path()),
+        None => uri.path().to_string(),
+    };
+    path.push(file_path);
+    let path = std::fs::canonicalize(&path)
+        .map_err(|e| zferror!(ErrorKind::IOError, "{}: {}", e, &path.to_string_lossy()))?;
+    Ok(path)
+}
+
+/// Returns the file extension, if any.
+pub(crate) fn get_file_extension(file: &Path) -> Option<String> {
+    if let Some(ext) = file.extension() {
+        if let Some(ext) = ext.to_str() {
+            return Some(String::from(ext));
+        }
+    }
+    None
+}
+
+/// Checks if the provided extension is that of a [`dynamic
+/// library`](`std::env::consts::DLL_EXTENSION`).
+pub(crate) fn is_dynamic_library(ext: &str) -> bool {
+    if ext == std::env::consts::DLL_EXTENSION {
+        return true;
+    }
+    false
+}

--- a/zenoh-flow/src/utils.rs
+++ b/zenoh-flow/src/utils.rs
@@ -43,6 +43,9 @@ pub(crate) fn try_make_file_path(url_str: &str) -> Result<PathBuf> {
     let mut path = PathBuf::new();
     #[cfg(test)]
     {
+        // When running the test on the CI we cannot know the path of the clone of Zenoh-Flow. By
+        // using relative paths (w.r.t. the manifest dir) in the tests and, only in tests, prepend
+        // the paths with this environment variable we obtain a correct absolute path.
         path.push(env!("CARGO_MANIFEST_DIR"));
     }
 


### PR DESCRIPTION
With this commit, all path declarations expect the same structure:

scheme://path

where the only scheme supported, for now, is `file`.

The only impact this change has is on the `descriptor` field of nodes:

(before)
```yaml
sources:
  - id: source
    descriptor: /path/to/descriptor
```

(after)
```yaml
sources:
  - id: source
    descriptor: file:///path/to/descriptor
```