### PR TITLE
refacto: remove tags from descriptors

### DIFF
--- a/cargo-zenoh-flow/src/bin/main.rs
+++ b/cargo-zenoh-flow/src/bin/main.rs
@@ -247,7 +247,6 @@ async fn main() {
                         outputs: outputs.clone(),
                         uri: Some(uri.clone()),
                         configuration: None,
-                        tags: vec![],
                     };
 
                     let metadata_arch = RegistryNodeArchitecture {
@@ -307,7 +306,6 @@ async fn main() {
                         outputs: outputs.clone(),
                         uri: Some(uri.clone()),
                         configuration: None,
-                        tags: vec![],
                     };
 
                     let metadata_arch = RegistryNodeArchitecture {
@@ -367,7 +365,6 @@ async fn main() {
                         inputs: inputs.clone(),
                         uri: Some(uri.clone()),
                         configuration: None,
-                        tags: vec![],
                     };
 
                     let metadata_arch = RegistryNodeArchitecture {

--- a/zenoh-flow/src/model/descriptor/node/operator.rs
+++ b/zenoh-flow/src/model/descriptor/node/operator.rs
@@ -40,7 +40,6 @@ use std::collections::HashMap;
 /// outputs:
 ///   - id: Multiplied
 ///     type: usize
-/// tags: [something]
 /// ```
 ///
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -50,7 +49,6 @@ pub struct OperatorDescriptor {
     pub outputs: Vec<PortDescriptor>,
     pub uri: Option<String>,
     pub configuration: Option<Configuration>,
-    pub tags: Vec<String>,
 }
 
 impl std::fmt::Display for OperatorDescriptor {

--- a/zenoh-flow/src/model/descriptor/node/sink.rs
+++ b/zenoh-flow/src/model/descriptor/node/sink.rs
@@ -31,7 +31,6 @@ use serde::{Deserialize, Serialize};
 /// input:
 ///   id: Data
 ///   type: usize
-/// tags: [linux]
 /// ```
 ///
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -40,7 +39,6 @@ pub struct SinkDescriptor {
     pub inputs: Vec<PortDescriptor>,
     pub uri: Option<String>,
     pub configuration: Option<Configuration>,
-    pub tags: Vec<String>,
 }
 
 impl std::fmt::Display for SinkDescriptor {

--- a/zenoh-flow/src/model/descriptor/node/source.rs
+++ b/zenoh-flow/src/model/descriptor/node/source.rs
@@ -31,7 +31,6 @@ use serde::{Deserialize, Serialize};
 /// output:
 ///   id: Counter
 ///   type: usize
-/// tags: []
 /// ```
 ///
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -40,7 +39,6 @@ pub struct SourceDescriptor {
     pub outputs: Vec<PortDescriptor>,
     pub uri: Option<String>,
     pub configuration: Option<Configuration>,
-    pub tags: Vec<String>,
 }
 
 impl std::fmt::Display for SourceDescriptor {

--- a/zenoh-flow/src/model/descriptor/tests/composite-outer.yml
+++ b/zenoh-flow/src/model/descriptor/tests/composite-outer.yml
@@ -9,5 +9,3 @@ inputs:
 outputs:
   - id: composite-outer-out
     type: _any_
-
-tags: []

--- a/zenoh-flow/src/model/descriptor/tests/flatten-composite.rs
+++ b/zenoh-flow/src/model/descriptor/tests/flatten-composite.rs
@@ -96,7 +96,6 @@ fn test_flatten_composite_descriptor_non_nested() {
             outputs: vec![PortDescriptor::new("operator-1-out", "_any_")],
             uri: Some("file://operator-1.so".into()),
             configuration: None,
-            tags: vec![],
         },
         OperatorDescriptor {
             id: "composite/my-operator-2".into(),
@@ -104,7 +103,6 @@ fn test_flatten_composite_descriptor_non_nested() {
             outputs: vec![PortDescriptor::new("operator-2-out", "_any_")],
             uri: Some("file://operator-2.so".into()),
             configuration: None,
-            tags: vec![],
         },
     ];
 
@@ -216,7 +214,6 @@ fn test_flatten_composite_descriptor_nested() {
             outputs: vec![PortDescriptor::new("composite-outer-out", "_any_")],
             uri: Some("file://composite-outer.so".into()),
             configuration: None,
-            tags: vec![],
         },
         OperatorDescriptor {
             id: "composite/composite-nested/operator-1".into(),
@@ -227,7 +224,6 @@ fn test_flatten_composite_descriptor_nested() {
             outputs: vec![PortDescriptor::new("operator-1-out", "_any_")],
             uri: Some("file://operator-1.so".into()),
             configuration: None,
-            tags: vec![],
         },
         OperatorDescriptor {
             id: "composite/composite-nested/operator-2".into(),
@@ -235,7 +231,6 @@ fn test_flatten_composite_descriptor_nested() {
             outputs: vec![PortDescriptor::new("operator-2-out", "_any_")],
             uri: Some("file://operator-2.so".into()),
             configuration: None,
-            tags: vec![],
         },
         OperatorDescriptor {
             id: "composite/composite-outer-i".into(),
@@ -243,7 +238,6 @@ fn test_flatten_composite_descriptor_nested() {
             outputs: vec![PortDescriptor::new("composite-outer-out", "_any_")],
             uri: Some("file://composite-outer.so".into()),
             configuration: None,
-            tags: vec![],
         },
     ];
 

--- a/zenoh-flow/src/model/descriptor/tests/flatten-descriptor.rs
+++ b/zenoh-flow/src/model/descriptor/tests/flatten-descriptor.rs
@@ -63,14 +63,12 @@ fn test_flatten_descriptor() {
             outputs: vec![PortDescriptor::new("source-out", "_any_")],
             uri: Some("file://source.so".into()),
             configuration: Some(json!({ "foo": "global-outer" })),
-            tags: vec![],
         },
         SourceDescriptor {
             id: "source-2".into(),
             outputs: vec![PortDescriptor::new("source-out", "_any_")],
             uri: Some("file://source.so".into()),
             configuration: Some(json!({ "foo": "global-outer" })),
-            tags: vec![],
         },
         SourceDescriptor {
             id: "source-composite".into(),
@@ -80,7 +78,6 @@ fn test_flatten_descriptor() {
             ],
             uri: Some("file://source-composite.so".into()),
             configuration: Some(json!({ "foo": "global-outer" })),
-            tags: vec![],
         },
     ];
 
@@ -104,7 +101,6 @@ fn test_flatten_descriptor() {
             outputs: vec![PortDescriptor::new("operator-out", "_any_")],
             uri: Some("file://operator.so".into()),
             configuration: Some(json!({ "foo": "global-outer" })),
-            tags: vec![],
         },
         OperatorDescriptor {
             id: "operator-2".into(),
@@ -112,7 +108,6 @@ fn test_flatten_descriptor() {
             outputs: vec![PortDescriptor::new("operator-out", "_any_")],
             uri: Some("file://operator.so".into()),
             configuration: Some(json!({ "foo": "global-outer" })),
-            tags: vec![],
         },
         /*
          * `sub-operator-1` is declared in the file "operator-composite.yml".
@@ -134,7 +129,6 @@ fn test_flatten_descriptor() {
             configuration: Some(
                 json!({ "foo": "global-outer", "quux": "global-inner", "bar": "composite-outer" }),
             ),
-            tags: vec![],
         },
         /*
          * Same spirit but this time it’s a composite operator within a composite operator. The
@@ -150,7 +144,6 @@ fn test_flatten_descriptor() {
             configuration: Some(
                 json!({ "foo": "global-outer", "quux": "global-inner", "bar": "composite-outer", "buzz": "composite-inner", "baz": "leaf" }),
             ),
-            tags: vec![],
         },
         /*
          * Idem as above: operator-composite/sub-operator-composite/sub-sub-operator-2.
@@ -163,7 +156,6 @@ fn test_flatten_descriptor() {
             configuration: Some(
                 json!({ "foo": "global-outer", "quux": "global-inner", "bar": "composite-outer", "buzz": "composite-inner" }),
             ),
-            tags: vec![],
         },
         /*
          * Similarly, we check that the name is the composition: operator-composite/sub-operator-2.
@@ -179,7 +171,6 @@ fn test_flatten_descriptor() {
             configuration: Some(
                 json!({ "foo": "global-outer", "quux": "global-inner", "bar": "composite-outer" }),
             ),
-            tags: vec![],
         },
     ];
 
@@ -202,14 +193,12 @@ fn test_flatten_descriptor() {
             inputs: vec![PortDescriptor::new("sink-in", "_any_")],
             uri: Some("file://sink.so".into()),
             configuration: Some(json!({ "foo": "global-outer" })),
-            tags: vec![],
         },
         SinkDescriptor {
             id: "sink-2".into(),
             inputs: vec![PortDescriptor::new("sink-in", "_any_")],
             uri: Some("file://sink.so".into()),
             configuration: Some(json!({ "foo": "global-outer" })),
-            tags: vec![],
         },
         SinkDescriptor {
             id: "sink-composite".into(),
@@ -219,7 +208,6 @@ fn test_flatten_descriptor() {
             ],
             uri: Some("file://sink-composite.so".into()),
             configuration: Some(json!({ "foo": "global-outer" })),
-            tags: vec![],
         },
     ];
 

--- a/zenoh-flow/src/model/descriptor/tests/operator-1.yml
+++ b/zenoh-flow/src/model/descriptor/tests/operator-1.yml
@@ -12,5 +12,3 @@ inputs:
 outputs:
   - id: operator-1-out
     type: _any_
-
-tags: []

--- a/zenoh-flow/src/model/descriptor/tests/operator-2.yml
+++ b/zenoh-flow/src/model/descriptor/tests/operator-2.yml
@@ -9,5 +9,3 @@ inputs:
 outputs:
   - id: operator-2-out
     type: _any_
-
-tags: []

--- a/zenoh-flow/src/model/descriptor/tests/operator.yml
+++ b/zenoh-flow/src/model/descriptor/tests/operator.yml
@@ -9,5 +9,3 @@ inputs:
 outputs:
   - id: operator-out
     type: _any_
-
-tags: []

--- a/zenoh-flow/src/model/descriptor/tests/sink-composite.yml
+++ b/zenoh-flow/src/model/descriptor/tests/sink-composite.yml
@@ -10,5 +10,3 @@ inputs:
     type: "{{  any }}"
   - id: sink-composite-in-2
     type: "{{ any    }}"
-
-tags: []

--- a/zenoh-flow/src/model/descriptor/tests/sink.yml
+++ b/zenoh-flow/src/model/descriptor/tests/sink.yml
@@ -5,5 +5,3 @@ uri: file://sink.so
 inputs:
   - id: sink-in
     type: _any_
-
-tags: []

--- a/zenoh-flow/src/model/descriptor/tests/source-composite.yml
+++ b/zenoh-flow/src/model/descriptor/tests/source-composite.yml
@@ -11,5 +11,3 @@ outputs:
     type: "{{ any }}"
   - id: source-composite-out-2
     type: "{{ any }}"
-
-tags: []

--- a/zenoh-flow/src/model/descriptor/tests/source.yml
+++ b/zenoh-flow/src/model/descriptor/tests/source.yml
@@ -5,5 +5,3 @@ uri: file://source.so
 outputs:
   - id: source-out
     type: _any_
-
-tags: []

--- a/zenoh-flow/src/model/descriptor/tests/sub-operator-1.yml
+++ b/zenoh-flow/src/model/descriptor/tests/sub-operator-1.yml
@@ -15,5 +15,3 @@ inputs:
 outputs:
   - id: sub-operator-1-out
     type: "{{ type-any }}"
-
-tags: []

--- a/zenoh-flow/src/model/descriptor/tests/sub-operator-2.yml
+++ b/zenoh-flow/src/model/descriptor/tests/sub-operator-2.yml
@@ -11,5 +11,3 @@ outputs:
     type: _any_
   - id: sub-operator-2-out-2
     type: _any_
-
-tags: []

--- a/zenoh-flow/src/model/descriptor/tests/sub-sub-operator-1.yml
+++ b/zenoh-flow/src/model/descriptor/tests/sub-sub-operator-1.yml
@@ -15,5 +15,3 @@ inputs:
 outputs:
   - id: sub-sub-operator-1-out
     type: _any_
-
-tags: []

--- a/zenoh-flow/src/model/descriptor/tests/sub-sub-operator-2.yml
+++ b/zenoh-flow/src/model/descriptor/tests/sub-sub-operator-2.yml
@@ -9,5 +9,3 @@ inputs:
 outputs:
   - id: sub-sub-operator-2-out
     type: _any_
-
-tags: []

--- a/zenoh-flow/tests/validator.rs
+++ b/zenoh-flow/tests/validator.rs
@@ -20,7 +20,6 @@ flow: SimplePipeline
 operators:
   - id : SumOperator
     uri: file://./target/release/libsum_and_send.dylib
-    tags: []
     inputs:
       - id: Number
         type: usize
@@ -30,14 +29,12 @@ operators:
 sources:
   - id : Counter
     uri: file://./target/release/libcounter_source.dylib
-    tags: []
     outputs:
       - id: Counter
         type: usize
 sinks:
   - id : PrintSink
     uri: file://./target/release/libgeneric_sink.dylib
-    tags: []
     inputs:
       - id: Data
         type: usize
@@ -68,7 +65,6 @@ flow: SimplePipeline
 operators:
   - id : SumOperator
     uri: file://./target/release/libsum_and_send.dylib
-    tags: []
     inputs:
       - id: Number
         type: usize
@@ -78,7 +74,6 @@ operators:
 sources:
   - id : Counter
     uri: file://./target/release/libcounter_source.dylib
-    tags: []
     outputs:
       - id: Counter
         type: usize
@@ -124,7 +119,6 @@ static DESCRIPTOR_KO_DIFFERENT_TYPES: &str = r#"
 flow: SimplePipeline
 operators:
   - id : SumOperator
-    tags: []
     uri: file://./target/release/libsum_and_send.dylib
     inputs:
       - id: Number
@@ -134,14 +128,12 @@ operators:
         type: isize
 sources:
   - id : Counter
-    tags: []
     uri: file://./target/release/libcounter_source.dylib
     outputs:
       - id: Counter
         type: usize
 sinks:
   - id : PrintSink
-    tags: []
     uri: file://./target/release/libgeneric_sink.dylib
     inputs:
       - id: Data
@@ -174,7 +166,6 @@ flow: SimplePipeline
 operators:
   - id : SumOperator
     uri: file://./target/release/libsum_and_send.dylib
-    tags: []
     inputs:
       - id: Number
         type: usize
@@ -186,14 +177,12 @@ operators:
 sources:
   - id : Counter
     uri: file://./target/release/libcounter_source.dylib
-    tags: []
     outputs:
       - id: Counter
         type: usize
 sinks:
   - id : PrintSink
     uri: file://./target/release/libgeneric_sink.dylib
-    tags: []
     inputs:
       - id: Data
         type: usize
@@ -226,7 +215,6 @@ flow: SimplePipeline
 operators:
   - id : SumOperator
     uri: file://./target/release/libsum_and_send.dylib
-    tags: []
     inputs:
       - id: Number
         type: usize
@@ -238,20 +226,17 @@ operators:
 sources:
   - id : Counter
     uri: file://./target/release/libcounter_source.dylib
-    tags: []
     outputs:
       - id: Counter
         type: usize
 sinks:
   - id : PrintSink
     uri: file://./target/release/libgeneric_sink.dylib
-    tags: []
     inputs:
       - id: Data
         type: usize
   - id : PrintSink2
     uri: file://./target/release/libgeneric_sink.dylib
-    tags: []
     inputs:
       - id: Data
         type: usize
@@ -289,7 +274,6 @@ flow: SimplePipeline
 operators:
   - id : SumOperator
     uri: file://./target/release/libsum_and_send.dylib
-    tags: []
     inputs:
       - id: Number
         type: usize
@@ -301,14 +285,12 @@ operators:
 sources:
   - id : Counter
     uri: file://./target/release/libcounter_source.dylib
-    tags: []
     outputs:
       - id: Counter
         type: usize
 sinks:
   - id : PrintSink
     uri: file://./target/release/libgeneric_sink.dylib
-    tags: []
     inputs:
       - id: Data
         type: usize
@@ -340,7 +322,6 @@ flow: SimplePipeline
 operators:
   - id : SumOperator
     uri: file://./target/release/libsum_and_send.dylib
-    tags: []
     inputs:
       - id: Number
         type: usize
@@ -350,20 +331,17 @@ operators:
 sources:
   - id : Counter
     uri: file://./target/release/libcounter_source.dylib
-    tags: []
     outputs:
       - id: Counter
         type: usize
   - id : Counter
     uri: file://./target/release/libcounter_source.dylib
-    tags: []
     outputs:
       - id: Counter
         type: usize
 sinks:
   - id : PrintSink
     uri: file://./target/release/libgeneric_sink.dylib
-    tags: []
     inputs:
       - id: Data
         type: usize
@@ -395,7 +373,6 @@ flow: SimplePipeline
 operators:
   - id : SumOperator
     uri: file://./target/release/libsum_and_send.dylib
-    tags: []
     inputs:
       - id: Number
         type: usize
@@ -405,20 +382,17 @@ operators:
 sources:
   - id : Counter
     uri: file://./target/release/libcounter_source.dylib
-    tags: []
     outputs:
       - id: Counter
         type: usize
 sinks:
   - id : PrintSink
     uri: file://./target/release/libgeneric_sink.dylib
-    tags: []
     inputs:
       - id: Data
         type: usize
   - id : PrintSink2
     uri: file://./target/release/libgeneric_sink.dylib
-    tags: []
     inputs:
       - id: Data
         type: usize
@@ -455,7 +429,6 @@ flow: SimplePipeline
 operators:
   - id : SumOperator
     uri: file://./target/release/libsum_and_send.dylib
-    tags: []
     inputs:
       - id: Number
         type: usize
@@ -465,14 +438,12 @@ operators:
 sources:
   - id : Counter
     uri: file://./target/release/libcounter_source.dylib
-    tags: []
     outputs:
       - id: Counter
         type: usize
 sinks:
   - id : PrintSink
     uri: file://./target/release/libgeneric_sink.dylib
-    tags: []
     inputs:
       - id: Data
         type: usize
@@ -504,7 +475,6 @@ flow: SimplePipeline
 operators:
   - id : SumOperator
     uri: file://./target/release/libsum_and_send.dylib
-    tags: []
     inputs:
       - id: Number
         type: usize
@@ -514,14 +484,12 @@ operators:
 sources:
   - id : Counter
     uri: file://./target/release/libcounter_source.dylib
-    tags: []
     outputs:
       - id: Counter
         type: usize
 sinks:
   - id : PrintSink
     uri: file://./target/release/libgeneric_sink.dylib
-    tags: []
     inputs:
       - id: Data
         type: usize
@@ -552,7 +520,6 @@ static DESCRIPTOR_OK_TYPE_ANY: &str = r#"
 flow: SimplePipeline
 operators:
   - id : SumOperator
-    tags: []
     uri: file://./target/release/libsum_and_send.dylib
     inputs:
       - id: Number
@@ -562,14 +529,12 @@ operators:
         type: isize
 sources:
   - id : Counter
-    tags: []
     uri: file://./target/release/libcounter_source.dylib
     outputs:
       - id: Counter
         type: usize
 sinks:
   - id : PrintSink
-    tags: []
     uri: file://./target/release/libgeneric_sink.dylib
     inputs:
       - id: Data


### PR DESCRIPTION
This PR removes the tags from all node descriptors, considering that we did
not yet develop this functionality.

Descriptors that include a section for tags will still be valid as that section
will simply be ignored.

Below is a now valid descriptor:

``` yaml
id: my-operator

inputs:
  - id: in
    type: String
    
outputs:
  - id: out
    type: String
    
uri: file:///absolute/path/to/the/implementation/libmy_operator.so
```