### PR TITLE
Changing default zfctl Zenoh configuration path to /etc/zenoh-flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Next, `zfctl`. We also need to copy a configuration file:
 
 ```bash
 mkdir -p ~/.config/zenoh-flow
-cp ./zfctl/.config/zfctl-zenoh.json ~/.config/zenoh-flow
+cp ./zfctl/.config/zfctl-zenoh.json /etc/zenoh-flow
 ```
 
 To check that the Zenoh-Flow daemon is correctly running and `zfctl` is set up, you can do:

--- a/zfctl/Cargo.toml
+++ b/zfctl/Cargo.toml
@@ -64,7 +64,7 @@ assets = [
     # binary
     ["target/release/zfctl", "/usr/bin/zfctl", "755"],
     # config
-    [".config/zfctl-zenoh.json", "~/.config/zenoh-flow/zfctl-zenoh.json", "644"]
+    [".config/zfctl-zenoh.json", "/etc/zenoh-flow/zfctl-zenoh.json", "644"]
 ]
 
 # RPM package configuration

--- a/zfctl/Cargo.toml
+++ b/zfctl/Cargo.toml
@@ -80,4 +80,4 @@ zfctl = { path = "/usr/bin/zfctl" }
 
 
 [package.metadata.rpm.files]
-"../.config/zfctl-zenoh.json" = { path = "~/.config/zenoh-flow/zfctl-zenoh.json", mode = "644" }
+"../.config/zfctl-zenoh.json" = { path = "/etc/zenoh-flow/zfctl-zenoh.json", mode = "644" }

--- a/zfctl/src/main.rs
+++ b/zfctl/src/main.rs
@@ -37,7 +37,7 @@ use zenoh_flow::runtime::DaemonInterfaceClient;
 
 const GIT_VERSION: &str = git_version!(prefix = "v", cargo_prefix = "v");
 
-const DEFAULT_ZENOH_CFG: &str = ".config/zenoh-flow/zfctl-zenoh.json";
+const DEFAULT_ZENOH_CFG: &str = "/etc/zenoh-flow/zfctl-zenoh.json";
 const ENV_ZENOH_CFG: &str = "ZFCTL_CFG";
 
 #[derive(Subcommand, Debug)]


### PR DESCRIPTION
Changing default zfctl Zenoh configuration path to /etc/zenoh-flow

Signed-off-by: gabrik <gabriele.baldoni@gmail.com>